### PR TITLE
Fix dataset test paths

### DIFF
--- a/battery_project/tests/test_dataset.py
+++ b/battery_project/tests/test_dataset.py
@@ -1,16 +1,18 @@
-import os
 import csv
+from pathlib import Path
 
-SAMPLE_FILE = os.path.join('battery_project', 'dataset', 'battery_sample.csv')
-DOWNLOAD_SCRIPT = os.path.join('battery_project', 'dataset', 'download_nasa_dataset.m')
+ROOT = Path(__file__).resolve().parents[1]
+SAMPLE_FILE = ROOT / "dataset" / "battery_sample.csv"
+DOWNLOAD_SCRIPT = ROOT / "dataset" / "download_nasa_dataset.m"
+MATLAB_FILE = ROOT / "matlab" / "battery_mimic.m"
 
 
 def test_sample_file_exists():
-    assert os.path.exists(SAMPLE_FILE)
+    assert SAMPLE_FILE.exists()
 
 
 def test_sample_file_columns_and_rows():
-    with open(SAMPLE_FILE, newline='') as f:
+    with open(str(SAMPLE_FILE), newline='') as f:
         reader = csv.reader(f)
         rows = list(reader)
     assert rows[0] == ['Time_s', 'Voltage_V', 'Current_A', 'Temperature_C']
@@ -18,14 +20,12 @@ def test_sample_file_columns_and_rows():
 
 
 def test_download_script_mentions_websave():
-    with open(DOWNLOAD_SCRIPT) as f:
+    with open(str(DOWNLOAD_SCRIPT)) as f:
         content = f.read()
     assert 'websave' in content
 
-MATLAB_FILE = os.path.join('battery_project', 'matlab', 'battery_mimic.m')
-
 def test_matlab_uses_builder_functions():
-    with open(MATLAB_FILE) as f:
+    with open(str(MATLAB_FILE)) as f:
         content = f.read()
     assert 'batteryCell' in content
     assert 'batteryBuilder' in content


### PR DESCRIPTION
## Summary
- use pathlib for dataset tests
- update open() calls to use str paths
- ensure tests work from root and subdir

## Testing
- `pytest -q`
- `(cd battery_project && pytest -q)`

------
https://chatgpt.com/codex/tasks/task_e_684befde71348326ab2d181d62499d81