### PR TITLE
Improve path handling in dataset tests

### DIFF
--- a/battery_project/tests/test_dataset.py
+++ b/battery_project/tests/test_dataset.py
@@ -1,8 +1,11 @@
 import os
 import csv
+from pathlib import Path
 
-SAMPLE_FILE = os.path.join('battery_project', 'dataset', 'battery_sample.csv')
-DOWNLOAD_SCRIPT = os.path.join('battery_project', 'dataset', 'download_nasa_dataset.m')
+BASE_DIR = Path(__file__).resolve().parents[1]
+SAMPLE_FILE = BASE_DIR / 'dataset' / 'battery_sample.csv'
+DOWNLOAD_SCRIPT = BASE_DIR / 'dataset' / 'download_nasa_dataset.m'
+MATLAB_FILE = BASE_DIR / 'matlab' / 'battery_mimic.m'
 
 
 def test_sample_file_exists():
@@ -22,7 +25,6 @@ def test_download_script_mentions_websave():
         content = f.read()
     assert 'websave' in content
 
-MATLAB_FILE = os.path.join('battery_project', 'matlab', 'battery_mimic.m')
 
 def test_matlab_uses_builder_functions():
     with open(MATLAB_FILE) as f:


### PR DESCRIPTION
## Summary
- use `Path(__file__).resolve()` to locate test directory
- build paths relative to the test file location

## Testing
- `pytest -q`
- `cd battery_project && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bf217dba88326a93495c89417db76