### PR TITLE
Fix dataset download script paths

### DIFF
--- a/battery_project/dataset/download_nasa_dataset.m
+++ b/battery_project/dataset/download_nasa_dataset.m
@@ -8,8 +8,9 @@
 % sufficient disk space and a stable internet connection.
 
 url = 'https://ti.arc.nasa.gov/c/13/'; % URL may change; update if needed
-zipFile = fullfile('dataset','NASA_Battery_Data.zip');
-outputDir = fullfile('dataset','nasa_raw');
+scriptDir = fileparts(mfilename('fullpath'));
+zipFile   = fullfile(scriptDir, 'NASA_Battery_Data.zip');
+outputDir = fullfile(scriptDir, 'nasa_raw');
 
 if ~isfolder(outputDir)
     mkdir(outputDir);


### PR DESCRIPTION
## Summary
- ensure `download_nasa_dataset.m` computes dataset paths relative to the script directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e8c12e148832684e708f243e7fa80